### PR TITLE
强制cmake最低版本为3.25

### DIFF
--- a/runtime/onnxruntime/CMakeLists.txt
+++ b/runtime/onnxruntime/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 project(wetts VERSION 0.1)
 


### PR DESCRIPTION
低版本的cmake可能导致无法编译openfst