### PR TITLE
[dataloader] Fix text filtering bug and speed up spectrum length calc

### DIFF
--- a/examples/aishell-3/run.sh
+++ b/examples/aishell-3/run.sh
@@ -39,6 +39,13 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     $data/lexicon.txt \
     $dataset_dir/data_aishell3 \
     $data/all.txt
+  
+  # Compute spec length (optional, but recommended)
+  python tools/compute_spec_length.py \
+    $data/all.txt \
+    $config \
+    $data/all_spec_length.txt
+  mv $data/all_spec_length.txt $data/all.txt
 
   cat $data/all.txt | awk -F '|' '{print $2}' | \
     sort | uniq | awk '{print $0, NR-1}' > $data/speaker.txt

--- a/examples/aishell-3/run.sh
+++ b/examples/aishell-3/run.sh
@@ -39,7 +39,7 @@ if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     $data/lexicon.txt \
     $dataset_dir/data_aishell3 \
     $data/all.txt
-  
+
   # Compute spec length (optional, but recommended)
   python tools/compute_spec_length.py \
     $data/all.txt \

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ torchvision
 tqdm
 transformers
 huggingface_hub
+soundfile

--- a/tools/compute_spec_length.py
+++ b/tools/compute_spec_length.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# author: @lsrami
+
+import os
+import sys
+import json
+from tqdm import tqdm
+import soundfile as sf
+from concurrent.futures import ThreadPoolExecutor
+
+
+def load_filepaths_and_text(filename, split="|"):
+    with open(filename, encoding="utf-8") as f:
+        filepaths_and_text = [line.strip().split(split) for line in f]
+    return filepaths_and_text
+
+def process_item(item):
+    audiopath = item[0]
+    src_sampling_rate = sf.info(audiopath).samplerate
+    text = item[2]
+    text = text.strip().split()
+    if min_text_len <= len(text) and len(text) <= max_text_len:
+        length = int(os.path.getsize(audiopath) * sampling_rate / src_sampling_rate) // (2 * hop_length)
+        item.append(length)
+        return item
+    else:
+        return None
+
+def main(in_file, out_file):
+    """
+    Filter text & store spec lengths
+    """
+
+    audiopaths_sid_text = load_filepaths_and_text(in_file, split="|")
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        results = list(tqdm(executor.map(process_item, audiopaths_sid_text), total=len(audiopaths_sid_text)))
+
+    # Filter out None results
+    results = [result for result in results if result is not None]
+
+    with open(out_file, "w", encoding="utf-8") as f:
+        for item in results:
+            f.write("|".join([str(i) for i in item]) + "\n")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <in_file> <config_file> <out_file>")
+        sys.exit(1)
+    in_file, config_file, out_file = sys.argv[1:4]
+
+    with open(config_file, "r", encoding="utf8") as f:
+        data = f.read()
+    config = json.loads(data)
+    hparams = config["data"]
+
+    min_text_len = hparams.get("min_text_len", 1)
+    max_text_len = hparams.get("max_text_len", 190)
+    sampling_rate = hparams.get("sampling_rate", 22050)
+    hop_length = hparams.get("hop_length", 256)
+    print(min_text_len, max_text_len, sampling_rate, hop_length)
+
+    main(in_file, out_file)

--- a/tools/compute_spec_length.py
+++ b/tools/compute_spec_length.py
@@ -14,17 +14,20 @@ def load_filepaths_and_text(filename, split="|"):
         filepaths_and_text = [line.strip().split(split) for line in f]
     return filepaths_and_text
 
+
 def process_item(item):
     audiopath = item[0]
     src_sampling_rate = sf.info(audiopath).samplerate
     text = item[2]
     text = text.strip().split()
     if min_text_len <= len(text) and len(text) <= max_text_len:
-        length = int(os.path.getsize(audiopath) * sampling_rate / src_sampling_rate) // (2 * hop_length)
+        length = int(os.path.getsize(audiopath) * sampling_rate /
+                     src_sampling_rate) // (2 * hop_length)
         item.append(length)
         return item
     else:
         return None
+
 
 def main(in_file, out_file):
     """
@@ -34,7 +37,12 @@ def main(in_file, out_file):
     audiopaths_sid_text = load_filepaths_and_text(in_file, split="|")
 
     with ThreadPoolExecutor(max_workers=32) as executor:
-        results = list(tqdm(executor.map(process_item, audiopaths_sid_text), total=len(audiopaths_sid_text)))
+        results = list(
+            tqdm(
+                executor.map(process_item, audiopaths_sid_text),
+                total=len(audiopaths_sid_text),
+            )
+        )
 
     # Filter out None results
     results = [result for result in results if result is not None]


### PR DESCRIPTION
1.修复了data_utils.py中的_filter时对文本长度的判断，原先未对文本长度split()，把空格也计算到文本长度了
2.更新了data_utils.py中的_filter时对音频采样率的计算从torchaudio替换为soundfile库，速度增加了5倍；
3.添加了data_utils.py中的_filter时进度条显示
4.添加 tools/compute_spec_length.py预先多线程计算频谱特征的长度，节省了数据加载时间，只需将原始的train.txt的文件格式变成 filename|speaker|text|spec_length，即用第四列表示特征的长度