### PR TITLE
[fix] Update train.py

### DIFF
--- a/wetts/vits/train.py
+++ b/wetts/vits/train.py
@@ -418,7 +418,7 @@ def train_and_evaluate(rank, local_rank, epoch, hps, nets, optims, schedulers, s
             y_mel = commons.slice_segments(
                 mel, ids_slice, hps.train.segment_size // hps.data.hop_length)
             y_hat_mel = mel_spectrogram_torch(
-                y_hat.squeeze(1),
+                y_hat.squeeze(1).float(),
                 hps.data.filter_length,
                 hps.data.n_mel_channels,
                 hps.data.sampling_rate,


### PR DESCRIPTION
训练过程中，某些设备在进行torch.stft时不支持half类型而报错，转换类型为float解决这个问题

```bash
  File "/public/home/user/wetts/examples/french-v1/vits/train.py", line 323, in main
    train_and_evaluate(
  File "/public/home/user/wetts/examples/french-v1/vits/train.py", line 429, in train_and_evaluate
    y_hat_mel = mel_spectrogram_torch(
  File "/public/home/user/wetts/wetts/vits/utils/mel_processing.py", line 167, in mel_spectrogram_torch
    spec = torch.stft(
  File "/public/home/user/miniconda3/envs/wetts/lib/python3.10/site-packages/torch/functional.py", line 632, in stft
    spec = torch.stft(
  File "/public/home/user/miniconda3/envs/wetts/lib/python3.10/site-packages/torch/functional.py", line 632, in stft
    spec = torch.stft(
    spec = torch.stft(
  File "/public/home/user/miniconda3/envs/wetts/lib/python3.10/site-packages/torch/functional.py", line 632, in stft
  File "/public/home/user/miniconda3/envs/wetts/lib/python3.10/site-packages/torch/functional.py", line 632, in stft
    return _VF.stft(input, n_fft, hop_length, win_length, window,  # type: ignore[attr-defined]
RuntimeError: hipFFT doesn't support transforms of type: Half    return _VF.stft(input, n_fft, hop_length, win_length, window,  # type: ignore[attr-defined]
```